### PR TITLE
Add S3 trigger to publish lambda

### DIFF
--- a/eventbrite/config.js
+++ b/eventbrite/config.js
@@ -28,7 +28,7 @@ const eventsParams = page =>
 module.exports = {
   buckets: () => ({
     producerBucket: "muxer-produced-events-eventbrite",
-    eventsBucket: "muxer-transformed-events"
+    eventsBucket: "muxer-events"
   }),
   getEventsUrl: ({ page }) => `${eventsApi}?${eventsParams(page)}`
 };

--- a/farsetlabs/config.js
+++ b/farsetlabs/config.js
@@ -17,7 +17,7 @@ const eventsParams = () =>
 module.exports = {
   buckets: () => ({
     producerBucket: "muxer-produced-events-farsetlabs",
-    eventsBucket: "muxer-transformed-events"
+    eventsBucket: "muxer-events"
   }),
   getEventsUrl: () => `${eventsApi}?${eventsParams()}`
 };

--- a/farsetlabs/handlers/transformer.js
+++ b/farsetlabs/handlers/transformer.js
@@ -37,6 +37,9 @@ const transformEvent = function(
       city: "Belfast",
       country: "GB"
     },
+    charge: {
+        is_free: true,
+    },
     created_at: new Date(created).toISOString(),
     last_updated: new Date(updated).toISOString(),
     source_data: {

--- a/farsetlabs/handlers/transformer.js
+++ b/farsetlabs/handlers/transformer.js
@@ -38,7 +38,7 @@ const transformEvent = function(
       country: "GB"
     },
     charge: {
-        is_free: true,
+      is_free: true
     },
     created_at: new Date(created).toISOString(),
     last_updated: new Date(updated).toISOString(),

--- a/meetupcom/config.js
+++ b/meetupcom/config.js
@@ -36,7 +36,7 @@ const eventsParams = convert({
 module.exports = {
   buckets: () => ({
     producerBucket: "muxer-produced-events-meetupcom",
-    eventsBucket: "muxer-transformed-events"
+    eventsBucket: "muxer-events"
   }),
   getGroupsUrl: () => `${groupsApi}?${groupsParams}`,
   getEventsUrl: slug => `${eventsApi(slug)}?${eventsParams}`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "farsetlabs:transformer:invoke": "cd farsetlabs && serverless invoke -f transform -l --aws-profile muxer",
     "farsetlabs:transformer:invoke-local": "cd farsetlabs && serverless invoke local -f transform",
     "farsetlabs:transformer:logs": "cd farsetlabs && serverless logs -f transform -l --aws-profile muxer",
+    "publisher:deploy": "cd publisher && serverless deploy -v --aws-profile muxer",
+    "publisher:s3deploy": "cd publisher && sls s3deploy --aws-profile=muxer",
     "publisher:publish:update": "cd publisher && serverless deploy function -f publish --aws-profile muxer",
     "publisher:publish:invoke": "cd publisher && serverless invoke -f publish -l --aws-profile muxer",
     "publisher:publish:invoke-local": "cd publisher && serverless invoke local -f publish",

--- a/publisher/config.js
+++ b/publisher/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   buckets: () => ({
-    eventsBucket: "muxer-transformed-events"
+    eventsBucket: "muxer-events"
   }),
-  muxerEventsApi: process.env.MUXER_EVENTS_API
+  muxerEventsApi: "https://muxer.co.uk/events"
 };

--- a/publisher/config.js
+++ b/publisher/config.js
@@ -2,5 +2,5 @@ module.exports = {
   buckets: () => ({
     eventsBucket: "muxer-events"
   }),
-  muxerEventsApi: "https://muxer.co.uk/events"
+  muxerEventsApi: process.env.MUXER_EVENTS_API
 };

--- a/publisher/handlers/publisher.js
+++ b/publisher/handlers/publisher.js
@@ -28,7 +28,7 @@ const convert = ({
   entry: charge.is_free ? ["free"] : ["ticket"],
   category: "technology",
   source: sourceData.name,
-  // source_id: sourceData.id,
+  source_id: sourceData.id,
   location: "belfast"
 });
 
@@ -39,7 +39,6 @@ const makeRequestFor = event =>
     json: true,
     body: convert(event)
   }).then(function(response) {
-    console.log(convert(event));
     if (`${response.statusCode}`.startsWith(2)) return response;
     throw new Error(`Unsuccessful request; ${response.statusCode}`);
   });

--- a/publisher/handlers/publisher.js
+++ b/publisher/handlers/publisher.js
@@ -28,7 +28,7 @@ const convert = ({
   entry: charge.is_free ? ["free"] : ["ticket"],
   category: "technology",
   source: sourceData.name,
-  source_id: sourceData.id,
+  // source_id: sourceData.id,
   location: "belfast"
 });
 
@@ -39,6 +39,7 @@ const makeRequestFor = event =>
     json: true,
     body: convert(event)
   }).then(function(response) {
+    console.log(convert(event));
     if (`${response.statusCode}`.startsWith(2)) return response;
     throw new Error(`Unsuccessful request; ${response.statusCode}`);
   });

--- a/publisher/package-lock.json
+++ b/publisher/package-lock.json
@@ -13,10 +13,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
       "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "asn1": {
@@ -24,7 +24,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -57,7 +57,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "caseless": {
@@ -70,7 +70,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "core-util-is": {
@@ -83,7 +83,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "delayed-stream": {
@@ -96,8 +96,8 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "extend": {
@@ -130,9 +130,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "getpass": {
@@ -140,7 +140,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "har-schema": {
@@ -153,8 +153,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.6.2",
+        "har-schema": "2.0.0"
       }
     },
     "http-signature": {
@@ -162,9 +162,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.0"
       }
     },
     "is-typedarray": {
@@ -223,7 +223,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "oauth-sign": {
@@ -256,26 +256,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "safe-buffer": {
@@ -288,20 +288,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "serverless-plugin-existing-s3": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-existing-s3/-/serverless-plugin-existing-s3-2.3.0.tgz",
+      "integrity": "sha512-lFj/QHvfiYQgCiW6FwZNL537mS5BgM3GyzyzhlMaKulGPQs0Ja4vO/l9eQgjZXQeShLeGDrHlFKY0thVLyFQeg=="
+    },
     "sshpk": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
       "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "tough-cookie": {
@@ -309,8 +314,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -325,7 +330,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -338,7 +343,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "uuid": {
@@ -351,9 +356,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     }
   }

--- a/publisher/package.json
+++ b/publisher/package.json
@@ -11,6 +11,7 @@
     "@muxer/event-schema": "1.0.0",
     "aws-lambda-data-utils": "1.0.0",
     "jsonschema": "1.2.4",
-    "request": "2.88.0"
+    "request": "2.88.0",
+    "serverless-plugin-existing-s3": "^2.3.0"
   }
 }

--- a/publisher/serverless.yml
+++ b/publisher/serverless.yml
@@ -21,27 +21,20 @@ functions:
     handler: handlers/publisher.publish
     environment:
       TZ: Europe/Belfast
+    events:
+      - existingS3:
+          bucket: ${self:custom.eventsBucket}
+          events:
+            - s3:ObjectCreated:*
+
 
 resources:
   Resources:
-    S3BucketMuxerTransformedEvents:
-      DependsOn:
-        - TransformLambdaPermissionS3BucketMuxerTransformedEventsS3
+    MuxerTransformedEventsS3Bucket:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:custom.eventsBucket}
-        NotificationConfiguration:
-          LambdaConfigurations:
-            - Event: "s3:ObjectCreated:*"
-              Function:
-                "Fn::GetAtt": [ TransformLambdaFunction, Arn ]
-    TransformLambdaPermissionS3BucketMuxerTransformedEventsS3:
-      DependsOn:
-        - TransformLambdaFunction
-      Type: AWS::Lambda::Permission
-      Properties:
-        FunctionName:
-          "Fn::GetAtt": [ TransformLambdaFunction, Arn ]
-        Action: "lambda:InvokeFunction"
-        Principal: "s3.amazonaws.com"
-        SourceArn: "arn:aws:s3:::${self:custom.eventsBucket}"
+
+
+plugins:
+  - serverless-plugin-existing-s3

--- a/tests/eventbrite/handlers/__snapshots__/tranformer.test.js.snap
+++ b/tests/eventbrite/handlers/__snapshots__/tranformer.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Eventbrite transformer when a new file is added to the bucket which contains complete events uploads transformed events list 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
@@ -387,7 +387,7 @@ Worst Case Scenario is the second show in the Zombie Science spoof lecture serie
 exports[`Eventbrite transformer when a new file is added to the bucket which contains incomplete events uploads transformed events list, without incomplete events 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
@@ -697,7 +697,7 @@ Worst Case Scenario is the second show in the Zombie Science spoof lecture serie
 exports[`Eventbrite transformer when multiple new files are added to the bucket uploads transformed events lists 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
@@ -1076,7 +1076,7 @@ Worst Case Scenario is the second show in the Zombie Science spoof lecture serie
     ],
   ],
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {

--- a/tests/eventbrite/handlers/tranformer.test.js
+++ b/tests/eventbrite/handlers/tranformer.test.js
@@ -80,7 +80,7 @@ describe("Eventbrite transformer", function() {
         transformer.transform(event, context, function() {
           expect(uploadTo).toHaveBeenCalledTimes(1);
           expect(uploadTo).toHaveBeenCalledWith(
-            "muxer-transformed-events",
+            "muxer-events",
             expect.any(Function),
             []
           );

--- a/tests/farsetlabs/handlers/__snapshots__/tranformer.test.js.snap
+++ b/tests/farsetlabs/handlers/__snapshots__/tranformer.test.js.snap
@@ -3,10 +3,13 @@
 exports[`Farsetlabs transformer when a new file is added to the bucket which contains complete events uploads transformed events list 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-05-21T10:21:12.000Z",
         "description": "https://www.meetup.com/CodeCoop-NI",
         "last_updated": "2018-05-21T10:33:48.120Z",
@@ -38,6 +41,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2017-09-19T08:01:05.000Z",
         "description": "http://www.farsetlabs.org.uk/events/coderdojo.html",
         "last_updated": "2017-09-19T08:01:06.267Z",
@@ -69,6 +75,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-08-10T19:01:39.000Z",
         "description": "Halloween Cyber Security Challenge (Because vulnerability is scary)
 Code Co-op: https://www.meetup.com/CodeCoop-NI/
@@ -102,6 +111,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2013-10-29T11:11:12.000Z",
         "description": " ",
         "last_updated": "2016-09-25T16:33:30.395Z",
@@ -133,6 +145,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-10-05T07:04:40.000Z",
         "description": "Details TBC",
         "last_updated": "2018-10-05T07:04:43.673Z",
@@ -171,10 +186,13 @@ Contact Zoe or Art for more details.",
 exports[`Farsetlabs transformer when a new file is added to the bucket which contains incomplete events uploads transformed events list, without incomplete events 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-05-21T10:21:12.000Z",
         "description": "https://www.meetup.com/CodeCoop-NI",
         "last_updated": "2018-05-21T10:33:48.120Z",
@@ -206,6 +224,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2017-09-19T08:01:05.000Z",
         "description": "http://www.farsetlabs.org.uk/events/coderdojo.html",
         "last_updated": "2017-09-19T08:01:06.267Z",
@@ -237,6 +258,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-08-10T19:01:39.000Z",
         "description": "Halloween Cyber Security Challenge (Because vulnerability is scary)
 Code Co-op: https://www.meetup.com/CodeCoop-NI/
@@ -270,6 +294,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-10-05T07:04:40.000Z",
         "description": "Details TBC",
         "last_updated": "2018-10-05T07:04:43.673Z",
@@ -308,10 +335,13 @@ Contact Zoe or Art for more details.",
 exports[`Farsetlabs transformer when multiple new files are added to the bucket uploads transformed events lists 1`] = `
 Array [
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-05-21T10:21:12.000Z",
         "description": "https://www.meetup.com/CodeCoop-NI",
         "last_updated": "2018-05-21T10:33:48.120Z",
@@ -343,6 +373,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2017-09-19T08:01:05.000Z",
         "description": "http://www.farsetlabs.org.uk/events/coderdojo.html",
         "last_updated": "2017-09-19T08:01:06.267Z",
@@ -374,6 +407,9 @@ Array [
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-08-10T19:01:39.000Z",
         "description": "Halloween Cyber Security Challenge (Because vulnerability is scary)
 Code Co-op: https://www.meetup.com/CodeCoop-NI/
@@ -407,6 +443,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2013-10-29T11:11:12.000Z",
         "description": " ",
         "last_updated": "2016-09-25T16:33:30.395Z",
@@ -438,6 +477,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-10-05T07:04:40.000Z",
         "description": "Details TBC",
         "last_updated": "2018-10-05T07:04:43.673Z",
@@ -471,10 +513,13 @@ Contact Zoe or Art for more details.",
     ],
   ],
   Array [
-    "muxer-transformed-events",
+    "muxer-events",
     [Function],
     Array [
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-05-21T10:21:12.000Z",
         "description": "https://www.meetup.com/CodeCoop-NI",
         "last_updated": "2018-05-21T10:33:48.120Z",
@@ -506,6 +551,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2017-09-19T08:01:05.000Z",
         "description": "http://www.farsetlabs.org.uk/events/coderdojo.html",
         "last_updated": "2017-09-19T08:01:06.267Z",
@@ -537,6 +585,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-08-10T19:01:39.000Z",
         "description": "Halloween Cyber Security Challenge (Because vulnerability is scary)
 Code Co-op: https://www.meetup.com/CodeCoop-NI/
@@ -570,6 +621,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2013-10-29T11:11:12.000Z",
         "description": " ",
         "last_updated": "2016-09-25T16:33:30.395Z",
@@ -601,6 +655,9 @@ Contact Zoe or Art for more details.",
         },
       },
       Object {
+        "charge": Object {
+          "is_free": true,
+        },
         "created_at": "2018-10-05T07:04:40.000Z",
         "description": "Details TBC",
         "last_updated": "2018-10-05T07:04:43.673Z",

--- a/tests/farsetlabs/handlers/tranformer.test.js
+++ b/tests/farsetlabs/handlers/tranformer.test.js
@@ -80,7 +80,7 @@ describe("Farsetlabs transformer", function() {
         transformer.transform(event, context, function() {
           expect(uploadTo).toHaveBeenCalledTimes(1);
           expect(uploadTo).toHaveBeenCalledWith(
-            "muxer-transformed-events",
+            "muxer-events",
             expect.any(Function),
             []
           );


### PR DESCRIPTION
### What's Changed

Updates publisher with a S3 Trigger to invoke the publish on object creation within the `muxer-events` bucket.

### What's Changed

* Introduces `serverless-plugin-existing-s3` to resolve existing s3 buckets
* Adds a missing parameter to Farset labs payload
* Renames `muxer-transformed-events` to `muxer-events`.
* Updates tests accordingly
